### PR TITLE
DatePicker Server Format

### DIFF
--- a/app/FormInner.tsx
+++ b/app/FormInner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { List } from 'immutable';
 import CheckBox from '../src/CheckBox/CheckBox';
 import Form from '../src/Form/Form';
@@ -144,17 +145,20 @@ export default class FormInner extends React.Component<{}, {}> {
           </div>
         </div>
         <br /><br />
-        <DateRange label="Date Range" name="DateRange" />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-
-        <DatePicker label="Date Picker" name="DatePicker1" />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        
-        <DatePicker label="Date Picker" name="DatePicker2" defaultValue="" />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+        <div className="clearfix" style={{ height: "300px" }}>
+          <div style={{ width: "300px", height: "300px", float: "left" }}>
+            <DateRange label="Date Range" name="DateRange" />
+          </div>
+          <div style={{ width: "300px", height: "300px", float: "left" }}>
+            <DatePicker label="Date Picker No Default" name="DatePickerNoDefault" />
+          </div>
+          <div style={{ width: "300px", height: "300px", float: "left" }}>
+            <DatePicker label="Date Picker Moment Object" name="DatePickerMomentObject" defaultValue={moment().format()} />
+          </div>
+          <div style={{ width: "300px", height: "300px", float: "left" }}>
+            <DatePicker label="Date Picker Blank Default" name="DatePickerBlankDefault" defaultValue="" />
+          </div>
+        </div>
         <button>Submit</button>
       </div>
     );

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -9,8 +9,8 @@ import "./DateRange.scss";
 
 class CalendarBase extends React.Component<DatePickerProps & PerformanceWrapperProps & DateWrapperPassedDownProps, {}>{
   handleChange = (dateRange:Moment) => {
-    const {inputChanged, close} = this.props
-    inputChanged(dateRange.format('DD/MM/YYYY'));
+    const {inputChanged, close} = this.props;
+    inputChanged(dateRange.format(this.props.serverFormat));
     if(typeof close === 'function'){
       close();
     }
@@ -26,7 +26,8 @@ class CalendarBase extends React.Component<DatePickerProps & PerformanceWrapperP
 class DatePicker extends React.Component<DatePickerProps & PerformanceWrapperProps, {}>{
   getValue = () => {
     const {value, defaultValue, dateFormat} = this.props;
-    const parsedValue = moment(value || defaultValue, 'DD/MM/YYYY');
+    const parsedValue = moment(value || defaultValue);
+
     if(parsedValue.isValid()) {
       return parsedValue.format(dateFormat);
     } else {
@@ -46,8 +47,9 @@ class DatePicker extends React.Component<DatePickerProps & PerformanceWrapperPro
 
 export default compose<DatePickerProps & PerformanceWrapperProps, DatePickerProps>(
   defaultProps({
-    defaultValue: moment().format('DD/MM/YYYY'),
-    dateFormat: 'DD/MM/YYYY'
+    defaultValue: moment().format(),
+    dateFormat: 'DD/MM/YYYY',
+    serverFormat: null
   }),
   performanceWrapper
 )(DatePicker);

--- a/src/Form/Types/types.ts
+++ b/src/Form/Types/types.ts
@@ -217,7 +217,8 @@ interface CommonDateProps extends BaseReactProps, NameProp, DateWrapperProps, On
 	theme?: Object,
 	onInit?: (date?: DateRangeMoment | Moment) => void | boolean,
 	minDate?: string | moment.Moment | Function,
-	maxDate?: string | moment.Moment | Function
+	maxDate?: string | moment.Moment | Function,
+	serverFormat?: string
 }
 
 export interface DatePickerProps extends CommonDateProps, DefaultValueProp<string>, ValueProp<Moment>{}


### PR DESCRIPTION
Allowed users to specify a `serverFormat` when using DatePicker. This separates the human readable `dateFormat` from the server ISO (default) format.