### PR TITLE
Added .input class to Select dropdowns

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -15,9 +15,9 @@ import './Select.scss';
 /** Class Select */
 class Select extends React.Component<SelectInputProps & PerformanceWrapperProps, {}> {
   render() {
-    const {className, label, labelPostfix, labelPrefix, arrow, ...props} = this.props
+    const {className, label, labelPostfix, labelPrefix, arrow, ...props} = this.props;
     const {autoFocus, onChange, onBlur, id, defaultChecked, defaultSelected, value, children, ...validationProps} = props;
-    const classes = classnames(className, "select")
+    const classes = classnames(className, "select", "input");
     return (
       <InputWrapper className={classes} name={props.name} labelPrefix={labelPrefix} labelPostfix={labelPostfix} label={label}>
         <div className="input-group">


### PR DESCRIPTION
This fixes a bug where Select components don't have the same stylings as other inputs due to the missing .input class