### PR TITLE
Add resize attribute to text area

### DIFF
--- a/app/FormInner.tsx
+++ b/app/FormInner.tsx
@@ -105,6 +105,23 @@ export default class FormInner extends React.Component<{}, {}> {
 						</div>
 					</div>
 
+					<div className="row">
+						<div className="tablet-col-12 margin-top-2">
+							<TextArea
+								name="message"
+								label="Message"
+								explanation={
+									<p>
+										Enter your message{' '}
+										<a href="https://google.com" target="_blank">
+											here
+										</a>
+									</p>
+								}
+							/>
+						</div>
+					</div>
+
 					{/* DATE & RANGE PICKERS */}
 					<div className="row">
 						<div className="tablet-col-6 margin-top-2">

--- a/server.js
+++ b/server.js
@@ -47,6 +47,6 @@ httpsServer.listen(port, function onStart(err) {
 	if (err) {
 		console.log(err);
 	}
-	open(url);
+
 	console.info('Listening to => %s in your browser.', url);
 });

--- a/src/Input/InputWrapper.tsx
+++ b/src/Input/InputWrapper.tsx
@@ -34,7 +34,7 @@ class InputWrapper extends React.Component<InputWrapperProps, undefined> {
 				)}
 				{explanation && (
 					<div className="input-description">
-						<p>{explanation}</p>
+						{typeof explanation === 'string' ? <p>{explanation}</p> : explanation}
 					</div>
 				)}
 				{children}

--- a/src/TextArea/Base.tsx
+++ b/src/TextArea/Base.tsx
@@ -11,6 +11,10 @@ import { TextAreaProps, PerformanceWrapperProps } from '../../typings/types.d';
 class TextAreaBase extends Component<TextAreaProps & PerformanceWrapperProps, {}> {
 	displayName: 'TextAreaBase';
 
+	static defaultProps = {
+		resize: 'none'
+	};
+
 	handleChange = (event: ChangeEvent<{ value: string }>) => {
 		const { inputChanged, onChange } = this.props;
 
@@ -30,8 +34,16 @@ class TextAreaBase extends Component<TextAreaProps & PerformanceWrapperProps, {}
 	};
 
 	render() {
+		const { resize } = this.props;
 		var attributes = getHTMLAttributes<TextAreaProps & PerformanceWrapperProps>(this.props);
-		return <textarea onBlur={this.handleBlur} onChange={this.handleChange} {...attributes} />;
+		return (
+			<textarea
+				onBlur={this.handleBlur}
+				onChange={this.handleChange}
+				{...attributes}
+				style={{ resize }}
+			/>
+		);
 	}
 }
 

--- a/src/TextArea/TextArea.scss
+++ b/src/TextArea/TextArea.scss
@@ -1,0 +1,10 @@
+.textarea {
+	.input-group {
+		height: auto;
+	}
+}
+
+textarea {
+	width: 100%;
+	border: 1px solid #dfdee3;
+}

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -9,13 +9,16 @@ import TextAreaBase from './Base';
 import DisplayValidation from '../Validation/DisplayValidation';
 import performanceWrapper from '../Form/Helpers/performanceWrapper';
 
+/** Styles */
+import './TextArea.scss';
+
 /** Interfaces */
 import { TextAreaProps, PerformanceWrapperProps } from '../../typings/types.d';
 
 /** Class TextArea */
 export class TextArea extends React.Component<TextAreaProps & PerformanceWrapperProps, {}> {
 	render() {
-		const { className, label, labelPrefix, labelPostfix, ...props } = this.props;
+		const { className, label, labelPrefix, labelPostfix, explanation, ...props } = this.props;
 		const { autoFocus, onChange, onBlur, id, value, ...validationProps } = props;
 		const classes = classnames(className, 'textarea', 'input');
 
@@ -25,7 +28,8 @@ export class TextArea extends React.Component<TextAreaProps & PerformanceWrapper
 				name={props.name}
 				labelPrefix={labelPrefix}
 				labelPostfix={labelPostfix}
-				label={label}>
+				label={label}
+				explanation={explanation}>
 				<InputGroup>
 					<TextAreaBase {...props} />
 				</InputGroup>

--- a/src/TextArea/TextArea.tsx
+++ b/src/TextArea/TextArea.tsx
@@ -19,7 +19,7 @@ import { TextAreaProps, PerformanceWrapperProps } from '../../typings/types.d';
 export class TextArea extends React.Component<TextAreaProps & PerformanceWrapperProps, {}> {
 	render() {
 		const { className, label, labelPrefix, labelPostfix, explanation, ...props } = this.props;
-		const { autoFocus, onChange, onBlur, id, value, ...validationProps } = props;
+		const { autoFocus, onChange, onBlur, id, value, resize, ...validationProps } = props;
 		const classes = classnames(className, 'textarea', 'input');
 
 		return (

--- a/src/TextArea/__tests__/TextArea.Test.js
+++ b/src/TextArea/__tests__/TextArea.Test.js
@@ -19,7 +19,9 @@ const allTextAreaProps = {
 	label: 'TextArea Label',
 	name: 'SampleTextArea',
 	className: 'SampleTextAreaClass',
-	id: 'TextAreaId'
+	id: 'TextAreaId',
+	explanation: 'This is additional explanation for this field',
+	resize: 'none'
 };
 
 const {
@@ -36,7 +38,9 @@ const {
 	append,
 	name,
 	className,
-	id
+	id,
+	explanation,
+	resize
 } = allTextAreaProps;
 
 const inputWrapperProps = {
@@ -44,7 +48,8 @@ const inputWrapperProps = {
 	name,
 	labelPostfix,
 	labelPrefix,
-	label
+	label,
+	explanation
 };
 
 const inputGroupProps = {};
@@ -57,7 +62,8 @@ const textAreaBaseProps = {
 	min,
 	max,
 	name,
-	pattern
+	pattern,
+	resize
 };
 
 const displayValidationProps = {

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -244,7 +244,7 @@ export interface InputWrapperProps extends BaseReactProps, LabelProp, NameProp, 
 
 	labelPostfix?: any;
 	/** Hint text */
-	explanation?: string;
+	explanation?: string | React.ReactElement<HTMLParagraphElement>;
 }
 
 export interface BaseInputProps<TDefault, TValue, TChangeEvent = React.ChangeEvent<{}>>
@@ -284,6 +284,8 @@ export interface TextAreaProps
 		AdditionalCompareProps {
 	/** The number of rows initially shown in the text area */
 	rows?: number;
+	/** The resizing behaviour of the textarea */
+	resize?: 'none' | 'vertical' | 'horizontal';
 }
 
 export interface TextInputProps


### PR DESCRIPTION
Adds the following features:

[ ] Resizing behaviour for textarea - `none`, `vertical`, `horizontal`
[ ] Can provide an additional explanation for the field
[ ] Occupies 100% width of the container. *NOTE* - add `TextArea` inside another container to control it width